### PR TITLE
xcode10-clean-fix

### DIFF
--- a/src/main/java/de/letsdev/maven/plugins/ios/ProjectBuilder.java
+++ b/src/main/java/de/letsdev/maven/plugins/ios/ProjectBuilder.java
@@ -290,7 +290,7 @@ public class ProjectBuilder {
     }
 
     private static void cleanXcodeProject(Map<String, String> properties, File workDirectory, List<String> xcodeBuildParameters) throws IOSException {
-        StringBuilder xcodebuildCommand = new StringBuilder("xcodebuild -alltargets -configuration " + properties.get(Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + " clean");
+        StringBuilder xcodebuildCommand = new StringBuilder("xcodebuild -alltargets -configuration " + properties.get(Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + " clean -scheme " + properties.get(Utils.PLUGIN_PROPERTIES.SCHEME.toString()));
 
         //add each dynamic parameter from pom
         for (String param : xcodeBuildParameters) {


### PR DESCRIPTION
Fixing the following error which occured with the new XCode Build System.
Error: 'error: This project is configured to use Xcode's new build system, but the new build system currently only supports the 'clean' action when passed -scheme.'