### PR TITLE
Feature/remove simulator architechtures

### DIFF
--- a/src/main/java/de/letsdev/maven/plugins/ios/ProjectBuilder.java
+++ b/src/main/java/de/letsdev/maven/plugins/ios/ProjectBuilder.java
@@ -40,7 +40,6 @@ public class ProjectBuilder {
 
     /**
      * @param properties Properties
-     *
      * @throws IOSException
      */
     public static void build(final Map<String, String> properties, MavenProject mavenProject,
@@ -126,14 +125,16 @@ public class ProjectBuilder {
                             targetDirectory.toString() + File.separator + properties.get(
                                     Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + "-" + Utils.SDK_IPHONE_OS
                                     + File.separator);
-                    frameworkPaths.add(targetWorkDirectoryIphone.getAbsolutePath() + File.separator + frameworkBuildName);
+                    frameworkPaths.add(
+                            targetWorkDirectoryIphone.getAbsolutePath() + File.separator + frameworkBuildName);
 
                     File targetWorkDirectoryIphoneSimulator = new File(
                             targetDirectory.toString() + File.separator + properties.get(
                                     Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + "-" + Utils.SDK_IPHONE_SIMULATOR
                                     + File.separator);
 
-                    //if we'd build the framework with xcodebuild archive command, we have to export the framework from archive
+                    //if we'd build the framework with xcodebuild archive command, we have to export the framework
+                    // from archive
                     if (Utils.shouldBuildXCArchive(properties)) {
                         File archiveFile = new File(Utils.getArchiveName(projectName, mavenProject));
                         exportProductArchive(archiveFile, targetWorkDirectoryIphone, frameworkBuildName);
@@ -142,12 +143,14 @@ public class ProjectBuilder {
                     }
 
                     if (shouldBuildSimulatorArchitectures) {
-                        frameworkPaths.add(targetWorkDirectoryIphoneSimulator.getAbsolutePath() + File.separator + frameworkBuildName);
+                        frameworkPaths.add(targetWorkDirectoryIphoneSimulator.getAbsolutePath() + File.separator
+                                + frameworkBuildName);
 
-                        // if we don't use xcframeworks, we have to merge framework binaries (iphoneOS + iphonesimulatorOS)
+                        // if we don't use xcframeworks, we have to merge framework binaries (iphoneOS +
+                        // iphonesimulatorOS)
                         if (!Utils.isiOSXcFramework(properties)) {
-                            mergeFrameworkProducts(targetWorkDirectoryIphone, targetWorkDirectoryIphoneSimulator, appName,
-                                    frameworkBuildName);
+                            mergeFrameworkProducts(targetWorkDirectoryIphone, targetWorkDirectoryIphoneSimulator,
+                                    appName, frameworkBuildName);
                         }
                     }
 
@@ -159,8 +162,7 @@ public class ProjectBuilder {
                 }
 
                 zipFrameworkArchive(properties, targetDependencies, frameworkTargetName, targetWorkDirectory);
-            }
-            else {
+            } else {
                 //unlock keychain
                 unlockKeychain(properties, mavenProject,
                         projectDirectory); //unlock it again, if during xcrun keychain is closed automatically again.
@@ -169,7 +171,8 @@ public class ProjectBuilder {
                     projectVersion += "-b" + properties.get(Utils.PLUGIN_PROPERTIES.BUILD_ID.toString());
                 }
 
-                generateIpaArchive(properties, mavenProject, xcodeExportOptions, schemeName, projectDirectory, targetDirectory, projectVersion);
+                generateIpaArchive(properties, mavenProject, xcodeExportOptions, schemeName, projectDirectory,
+                        targetDirectory, projectVersion);
             }
 
             //lock keychain
@@ -195,40 +198,47 @@ public class ProjectBuilder {
         }
     }
 
-    private static void generateIpaArchive(Map<String, String> properties, MavenProject mavenProject, XcodeExportOptions xcodeExportOptions, String schemeName, File projectDirectory, File targetDirectory, String projectVersion) throws IOSException {
-        File appTargetPath = new File(targetDirectory + File.separator + properties.get(
-                Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + "-" + Utils.SDK_IPHONE_OS + "/" + properties
-                .get(Utils.PLUGIN_PROPERTIES.TARGET.toString()) + "." + Utils.PLUGIN_SUFFIX.APP);
+    private static void generateIpaArchive(Map<String, String> properties, MavenProject mavenProject,
+                                           XcodeExportOptions xcodeExportOptions, String schemeName,
+                                           File projectDirectory, File targetDirectory,
+                                           String projectVersion) throws IOSException {
 
-        File newAppTargetPath = new File(targetDirectory + File.separator + properties.get(
-                Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + "-" + Utils.SDK_IPHONE_OS + "/" + properties
-                .get(Utils.PLUGIN_PROPERTIES.APP_NAME.toString()) + "." + Utils.PLUGIN_SUFFIX.APP);
+        File appTargetPath = new File(
+                targetDirectory + File.separator + properties.get(Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString())
+                        + "-" + Utils.SDK_IPHONE_OS + "/" + properties.get(Utils.PLUGIN_PROPERTIES.TARGET.toString())
+                        + "." + Utils.PLUGIN_SUFFIX.APP);
 
-        File ipaBasePath = new File(targetDirectory + File.separator + properties.get(
-                Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + "-" + Utils.SDK_IPHONE_OS);
+        File newAppTargetPath = new File(
+                targetDirectory + File.separator + properties.get(Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString())
+                        + "-" + Utils.SDK_IPHONE_OS + "/" + properties.get(Utils.PLUGIN_PROPERTIES.APP_NAME.toString())
+                        + "." + Utils.PLUGIN_SUFFIX.APP);
 
-        File ipaTargetPath = new File(ipaBasePath.getAbsolutePath() + "/" + properties.get(
-                Utils.PLUGIN_PROPERTIES.APP_NAME.toString()) + "-" + projectVersion + "."
-                + Utils.PLUGIN_SUFFIX.IPA);
+        File ipaBasePath = new File(
+                targetDirectory + File.separator + properties.get(Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString())
+                        + "-" + Utils.SDK_IPHONE_OS);
 
-        File dsymTargetPath = new File(targetDirectory + File.separator + properties.get(
-                Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + "-" + Utils.SDK_IPHONE_OS + "/" + properties
-                .get(Utils.PLUGIN_PROPERTIES.TARGET.toString()) + "." + Utils.PLUGIN_SUFFIX.APP_DSYM);
+        File ipaTargetPath = new File(
+                ipaBasePath.getAbsolutePath() + "/" + properties.get(Utils.PLUGIN_PROPERTIES.APP_NAME.toString()) + "-"
+                        + projectVersion + "." + Utils.PLUGIN_SUFFIX.IPA);
 
-        File newDsymTargetPath = new File(targetDirectory + File.separator + properties.get(
-                Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + "-" + Utils.SDK_IPHONE_OS + "/" + properties
-                .get(Utils.PLUGIN_PROPERTIES.APP_NAME.toString()) + "." + Utils.PLUGIN_SUFFIX.APP_DSYM);
+        File dsymTargetPath = new File(
+                targetDirectory + File.separator + properties.get(Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString())
+                        + "-" + Utils.SDK_IPHONE_OS + "/" + properties.get(Utils.PLUGIN_PROPERTIES.TARGET.toString())
+                        + "." + Utils.PLUGIN_SUFFIX.APP_DSYM);
 
-        if (appTargetPath.exists() && !(appTargetPath.toString()
-                .equalsIgnoreCase(newAppTargetPath.toString()))) {
+        File newDsymTargetPath = new File(
+                targetDirectory + File.separator + properties.get(Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString())
+                        + "-" + Utils.SDK_IPHONE_OS + "/" + properties.get(Utils.PLUGIN_PROPERTIES.APP_NAME.toString())
+                        + "." + Utils.PLUGIN_SUFFIX.APP_DSYM);
+
+        if (appTargetPath.exists() && !(appTargetPath.toString().equalsIgnoreCase(newAppTargetPath.toString()))) {
             ProcessBuilder processBuilder = new ProcessBuilder("mv", appTargetPath.toString(),
                     newAppTargetPath.toString());
             processBuilder.directory(projectDirectory);
             CommandHelper.performCommand(processBuilder);
         }
 
-        if (dsymTargetPath.exists() && !(dsymTargetPath.toString()
-                .equalsIgnoreCase(newDsymTargetPath.toString()))) {
+        if (dsymTargetPath.exists() && !(dsymTargetPath.toString().equalsIgnoreCase(newDsymTargetPath.toString()))) {
             ProcessBuilder processBuilder = new ProcessBuilder("mv", dsymTargetPath.toString(),
                     newDsymTargetPath.toString());
             processBuilder.directory(projectDirectory);
@@ -242,8 +252,8 @@ public class ProjectBuilder {
         }
 
         if (Utils.shouldBuildXCArchiveWithExportOptionsPlist(xcodeExportOptions)) {
-            codeSignAfterXcode8_3(properties, mavenProject, projectDirectory, Utils.getIpaName(schemeName),
-                    ipaBasePath, ipaTargetPath, ipaTmpDir, xcodeExportOptions);
+            codeSignAfterXcode8_3(properties, mavenProject, projectDirectory, Utils.getIpaName(schemeName), ipaBasePath,
+                    ipaTargetPath, ipaTmpDir, xcodeExportOptions);
         } else if (Utils.shouldBuildXCArchive(properties)) {
             codeSignAfterXcode6(properties, mavenProject, projectDirectory, ipaTargetPath);
         } else {
@@ -251,7 +261,8 @@ public class ProjectBuilder {
         }
     }
 
-    private static void zipFrameworkArchive(Map<String, String> properties, List<String> targetDependencies, String frameworkName, File targetWorkDirectory) throws IOSException {
+    private static void zipFrameworkArchive(Map<String, String> properties, List<String> targetDependencies,
+                                            String frameworkName, File targetWorkDirectory) throws IOSException {
         // Zip Frameworks
         String targetZipPath = "../" + properties.get(Utils.PLUGIN_PROPERTIES.APP_NAME.toString()) + "."
                 + Utils.PLUGIN_SUFFIX.FRAMEWORK_ZIP.toString();
@@ -267,7 +278,9 @@ public class ProjectBuilder {
         CommandHelper.performCommand(processBuilder);
     }
 
-    private static void generateXcFramework(List<String> frameworkPaths, String frameworkTargetName, File targetWorkDirectory) throws IOSException {
+    private static void generateXcFramework(List<String> frameworkPaths, String frameworkTargetName,
+                                            File targetWorkDirectory) throws IOSException {
+
         StringBuilder buildCommand = new StringBuilder();
         buildCommand.append("xcodebuild");
         buildCommand.append(" -create-xcframework");
@@ -350,8 +363,7 @@ public class ProjectBuilder {
 
         StringBuilder xcodebuildCommand = new StringBuilder("xcodebuild -alltargets -configuration " + properties.get(
                 Utils.PLUGIN_PROPERTIES.CONFIGURATION.toString()) + " clean -scheme " + properties.get(
-                Utils.PLUGIN_PROPERTIES.SCHEME.toString()) + " -sdk " + sdk
-                );
+                Utils.PLUGIN_PROPERTIES.SCHEME.toString()) + " -sdk " + sdk);
 
         //add each dynamic parameter from pom
         for (String param : xcodeBuildParameters) {
@@ -742,8 +754,7 @@ public class ProjectBuilder {
         // Run shell-script from resource-folder.
         final String scriptName = "merge-framework-products";
 
-        final String iphoneosFrameworkProductPath =
-                targetWorkDirectoryIphone.toString() + "/" + frameworkName;
+        final String iphoneosFrameworkProductPath = targetWorkDirectoryIphone.toString() + "/" + frameworkName;
         final String iphoneSimulatorFrameworkProductPath =
                 targetWorkDirectoryIphoneSimulator.toString() + "/" + frameworkName;
         final String mergedFrameworkPath = targetWorkDirectoryIphone.toString() + "/" + frameworkName;

--- a/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
+++ b/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
@@ -28,6 +28,7 @@ public class ProjectTester {
         File targetDirectory = Utils.getTargetDirectory(mavenProject);
 
         copyArchitecturesToDirectory(targetDirectory);
+        copyArchitecturesToDirectory(workDirectory);
 
         if (Utils.shouldResetIphoneSimulators(properties)) {
             resetSimulators(workDirectory);

--- a/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
+++ b/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
@@ -49,10 +49,11 @@ public class ProjectTester {
         }
 
         if (properties.containsKey(Utils.PLUGIN_PROPERTIES.XCTEST_DERIVED_DATA_PATH.toString())) {
-            otherArguments.append(" " + "-derivedDataPath ").append(properties.get(
-                    Utils.PLUGIN_PROPERTIES.XCTEST_DERIVED_DATA_PATH.toString()));
+            otherArguments.append(" " + "-derivedDataPath ")
+                    .append(properties.get(Utils.PLUGIN_PROPERTIES.XCTEST_DERIVED_DATA_PATH.toString()));
         } else if (properties.containsKey(Utils.PLUGIN_PROPERTIES.DERIVED_DATA_PATH.toString())) {
-            otherArguments.append(" " + "-derivedDataPath ").append(properties.get(Utils.PLUGIN_PROPERTIES.DERIVED_DATA_PATH.toString()));
+            otherArguments.append(" " + "-derivedDataPath ")
+                    .append(properties.get(Utils.PLUGIN_PROPERTIES.DERIVED_DATA_PATH.toString()));
         }
 
         String jsonOutputFile = Utils.createJsonOutputFilePath("test", properties);

--- a/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
+++ b/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
@@ -27,9 +27,7 @@ public class ProjectTester {
         File workDirectory = Utils.getWorkDirectory(properties, mavenProject, projectName);
         File targetDirectory = Utils.getTargetDirectory(mavenProject);
 
-        //if (xcodeExportOptions.method != null && xcodeExportOptions.method.equals("app-store")) {
-            copyArchitecturesToDirectory(targetDirectory);
-        //}
+        copyArchitecturesToDirectory(targetDirectory);
 
         if (Utils.shouldResetIphoneSimulators(properties)) {
             resetSimulators(workDirectory);

--- a/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
+++ b/src/main/java/de/letsdev/maven/plugins/ios/ProjectTester.java
@@ -25,6 +25,11 @@ public class ProjectTester {
 
         String projectName = Utils.buildProjectName(properties, mavenProject);
         File workDirectory = Utils.getWorkDirectory(properties, mavenProject, projectName);
+        File targetDirectory = Utils.getTargetDirectory(mavenProject);
+
+        //if (xcodeExportOptions.method != null && xcodeExportOptions.method.equals("app-store")) {
+            copyArchitecturesToDirectory(targetDirectory);
+        //}
 
         if (Utils.shouldResetIphoneSimulators(properties)) {
             resetSimulators(workDirectory);
@@ -75,5 +80,21 @@ public class ProjectTester {
         ProcessBuilder processBuilder = new ProcessBuilder("/bin/bash", tempFile.getAbsoluteFile().toString());
         processBuilder.directory(workDirectory);
         CommandHelper.performCommand(processBuilder);
+    }
+
+    private static void copyArchitecturesToDirectory(File rootDirectory) {
+        // Run shell-script from resource-folder.
+        try {
+            final String scriptName = "copy-dependencies-back-to-target.sh";
+            File tempFile = Utils.createTempFile(scriptName);
+            ProcessBuilder processBuilder = new ProcessBuilder("sh", tempFile.getAbsoluteFile().toString(),
+                    rootDirectory.getAbsolutePath());
+
+            processBuilder.directory(rootDirectory);
+            CommandHelper.performCommand(processBuilder);
+        } catch (IOException | IOSException e) {
+            e.printStackTrace();
+            //throw new IOSException(e);
+        }
     }
 }

--- a/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
+++ b/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
@@ -2,9 +2,9 @@
 
 APP_PATH="$1"
 cd "$APP_PATH"
-if [[ -d dependecies-copy ]]; then
+if [[ -d dependencies-copy ]]; then
     echo "Original Frameworks will be copied back for testing to dependencies"
     rm -rf ios-dependencies
-    cp -a dependecies-copy ios-dependencies
-    rm -rf dependecies-copy
+    cp -a dependencies-copy ios-dependencies
+    rm -rf dependencies-copy
 fi

--- a/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
+++ b/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
@@ -2,9 +2,9 @@
 
 APP_PATH="$1"
 cd "$APP_PATH"
-if [[ -d ../tmp-target ]]; then
-    echo "Dependencies will be copied back to target from tmp-target"
+if [[ -d dependecies-copy ]]; then
+    echo "Original Frameworks will be copied back for testing to dependencies"
     rm -rf ios-dependencies
-    cp -a ../tmp-target ios-dependencies
-    rm -rf ../tmp-target
+    cp -a dependecies-copy ios-dependencies
+    rm -rf dependecies-copy
 fi

--- a/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
+++ b/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 APP_PATH="$1"
-echo "Dependencies will be copied back to target from tmp-target"
 cd "$APP_PATH"
-rm -rf ios-dependencies
-cp -a ../tmp-target ios-dependencies
-rm -rf ../tmp-target
+if [[ -d ../tmp-target ]]; then
+    echo "Dependencies will be copied back to target from tmp-target"
+    rm -rf ios-dependencies
+    cp -a ../tmp-target ios-dependencies
+    rm -rf ../tmp-target
+fi

--- a/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
+++ b/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
@@ -2,9 +2,11 @@
 
 APP_PATH="$1"
 cd "$APP_PATH"
-if [[ -d dependencies-copy ]]; then
+
+DEPENDENCIES_COPY_PATH="dependencies-copy"
+
+if [[ -d $DEPENDENCIES_COPY_PATH ]]; then
     echo "Original Frameworks will be copied back for testing to dependencies"
-    rm -rf ios-dependencies
-    cp -a dependencies-copy ios-dependencies
-    rm -rf dependencies-copy
+    cp -a "$DEPENDENCIES_COPY_PATH/." ./
+    rm -rf $DEPENDENCIES_COPY_PATH
 fi

--- a/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
+++ b/src/main/resources/META-INF/copy-dependencies-back-to-target.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+APP_PATH="$1"
+echo "Dependencies will be copied back to target from tmp-target"
+cd "$APP_PATH"
+rm -rf ios-dependencies
+cp -a ../tmp-target ios-dependencies
+rm -rf ../tmp-target

--- a/src/main/resources/META-INF/remove-simulator-archs.sh
+++ b/src/main/resources/META-INF/remove-simulator-archs.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
 APP_PATH="$1"
+echo "Hello here is the begin of the script"
 find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
 do
     echo "Trying to remove simulator architectures from framework: ""$FRAMEWORK"
+    mkdir ../tmp-target
+    cp -a "$FRAMEWORK" ../tmp-target/
     for subFile in "$FRAMEWORK"/*; do
     if [[ -f "$subFile" ]]; then
     if [[ -x "$subFile" ]]; then

--- a/src/main/resources/META-INF/remove-simulator-archs.sh
+++ b/src/main/resources/META-INF/remove-simulator-archs.sh
@@ -1,19 +1,33 @@
 #!/bin/sh
 
 APP_PATH="$1"
-mkdir dependencies-copy
-find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
+cd $APP_PATH
+
+DEPENDENCIES_COPY_PATH="dependencies-copy"
+mkdir -p $DEPENDENCIES_COPY_PATH
+find . -name '*.framework' -type d | while read -r FRAMEWORK
 do
     echo "Trying to remove simulator architectures from framework: ""$FRAMEWORK"
-    cp -a "$FRAMEWORK" dependencies-copy
+
+    FRAMEWORK_DIR=$(dirname "$FRAMEWORK")
+    FRAMEWORK_DIR="$DEPENDENCIES_COPY_PATH/${FRAMEWORK_DIR//.\/}"
+    echo "Saving a copy of the framework with all architectures to $FRAMEWORK_DIR"
+    mkdir -p $FRAMEWORK_DIR
+    cp -a "$FRAMEWORK" $FRAMEWORK_DIR
+
     for subFile in "$FRAMEWORK"/*; do
     if [[ -f "$subFile" ]]; then
-    if [[ -x "$subFile" ]]; then
-        echo "Trying to remove i386 from $subFile"
-        lipo -remove i386 "$subFile" -o "$subFile";
-        echo "Trying to remove x86_64 from $subFile"
-        lipo -remove x86_64 "$subFile" -o "$subFile";
-    fi
+        if ! [ "${subFile##*.}" = "plist" ]; then
+            if lipo $subFile -verify_arch i386; then
+                echo "Trying to remove i386 from $subFile"
+                lipo -remove i386 "$subFile" -o "$subFile";
+            fi
+
+            if lipo $subFile -verify_arch x86_64; then
+                echo "Trying to remove x86_64 from $subFile"
+                lipo -remove x86_64 "$subFile" -o "$subFile";
+            fi
+        fi
     fi
     done
 ##fi

--- a/src/main/resources/META-INF/remove-simulator-archs.sh
+++ b/src/main/resources/META-INF/remove-simulator-archs.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 APP_PATH="$1"
-mkdir dependecies-copy
+mkdir dependencies-copy
 find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
 do
     echo "Trying to remove simulator architectures from framework: ""$FRAMEWORK"
-    cp -a "$FRAMEWORK" dependecies-copy
+    cp -a "$FRAMEWORK" dependencies-copy
     for subFile in "$FRAMEWORK"/*; do
     if [[ -f "$subFile" ]]; then
     if [[ -x "$subFile" ]]; then

--- a/src/main/resources/META-INF/remove-simulator-archs.sh
+++ b/src/main/resources/META-INF/remove-simulator-archs.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
 APP_PATH="$1"
-mkdir ../tmp-target
+mkdir dependecies-copy
 find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
 do
     echo "Trying to remove simulator architectures from framework: ""$FRAMEWORK"
-    cp -a "$FRAMEWORK" ../tmp-target/
+    cp -a "$FRAMEWORK" dependecies-copy
     for subFile in "$FRAMEWORK"/*; do
     if [[ -f "$subFile" ]]; then
-    #if [[ -x "$subFile" ]]; then
+    if [[ -x "$subFile" ]]; then
         echo "Trying to remove i386 from $subFile"
         lipo -remove i386 "$subFile" -o "$subFile";
         echo "Trying to remove x86_64 from $subFile"
         lipo -remove x86_64 "$subFile" -o "$subFile";
-    #fi
+    fi
     fi
     done
 ##fi

--- a/src/main/resources/META-INF/remove-simulator-archs.sh
+++ b/src/main/resources/META-INF/remove-simulator-archs.sh
@@ -1,20 +1,19 @@
 #!/bin/sh
 
 APP_PATH="$1"
-echo "Hello here is the begin of the script"
+mkdir ../tmp-target
 find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
 do
     echo "Trying to remove simulator architectures from framework: ""$FRAMEWORK"
-    mkdir ../tmp-target
     cp -a "$FRAMEWORK" ../tmp-target/
     for subFile in "$FRAMEWORK"/*; do
     if [[ -f "$subFile" ]]; then
-    if [[ -x "$subFile" ]]; then
+    #if [[ -x "$subFile" ]]; then
         echo "Trying to remove i386 from $subFile"
         lipo -remove i386 "$subFile" -o "$subFile";
         echo "Trying to remove x86_64 from $subFile"
         lipo -remove x86_64 "$subFile" -o "$subFile";
-    fi
+    #fi
     fi
     done
 ##fi


### PR DESCRIPTION
Before simulator architectures get removed all dependencies are copied to a other directory, so we can copy them back if we need those architectures for testing.