### PR TITLE
set info.plist entries crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
+### Changed
+- fixed issue with crash after setting some parameters in "Info.plist" file
 
 ## [1.19.0] - 2020-04-09
 ### Added

--- a/src/main/resources/META-INF/write-buildnumber.sh
+++ b/src/main/resources/META-INF/write-buildnumber.sh
@@ -8,4 +8,5 @@ echo "OLD BUILD NUMBER=$(/usr/libexec/PlistBuddy -c "Print CFBuildNumber" $PLIST
 echo "NEW BUILD NUMBER= $NEW_BUILD_NUMBER"
 
 echo "Write NEW Build Number into PLIST now"
-/usr/libexec/PlistBuddy -c "Set :CFBuildNumber $NEW_BUILD_NUMBER" $PLIST_LOCATION
+/usr/libexec/PlistBuddy -c "Delete :CFBuildNumber" $PLIST_LOCATION
+/usr/libexec/PlistBuddy -c "Add :CFBuildNumber string $NEW_BUILD_NUMBER" $PLIST_LOCATION

--- a/src/main/resources/META-INF/write-bundleidentifier.sh
+++ b/src/main/resources/META-INF/write-bundleidentifier.sh
@@ -8,4 +8,5 @@ echo "OLD BUNDLE IDENTIFIER=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifi
 echo "NEW BUNDLE IDENTIFIER= $NEW_BUNDLE_IDENTIFIER"
 
 echo "Write NEW BUNDLE IDENTIFIER into PLIST now"
-/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $NEW_BUNDLE_IDENTIFIER" $PLIST_LOCATION
+/usr/libexec/PlistBuddy -c "Delete :CFBundleIdentifier" $PLIST_LOCATION
+/usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string $NEW_BUNDLE_IDENTIFIER" $PLIST_LOCATION

--- a/src/main/resources/META-INF/write-displayname.sh
+++ b/src/main/resources/META-INF/write-displayname.sh
@@ -8,4 +8,5 @@ echo "OLD DISPLAY NAME=$(/usr/libexec/PlistBuddy -c "Print CFBundleDisplayName" 
 echo "NEW DISPLAY NAME= $NEW_DISPLAY_NAME"
 
 echo "Write NEW DISPLAY NAME into PLIST now"
-/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $NEW_DISPLAY_NAME" $PLIST_LOCATION
+/usr/libexec/PlistBuddy -c "Delete :CFBundleDisplayName" $PLIST_LOCATION
+/usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string $NEW_DISPLAY_NAME" $PLIST_LOCATION


### PR DESCRIPTION
Fixed an issue that resulted in a crash, when CFBundleIdentifier, CFBuildNumber or CFBundleDisplayName weren't set